### PR TITLE
Avoid up time logging in SG500X v1.4.0.88

### DIFF
--- a/src/csbrancid
+++ b/src/csbrancid
@@ -169,13 +169,29 @@ sub sortbyipaddr {
 sub ShowSystem {
     print STDERR "    In ShowSystem: $_" if ($debug);
 
+    local $_ = <INPUT>;
+    seek(INPUT, -length($_), 1);
+
+    if (/command authorization failed/i) {
+	return(-1);
+    } elsif (/^$prompt/) {
+	return(0);
+    } elsif (/^\s*$/) {
+	ShowSystemSections();
+    } else {
+	ShowSystemLines();
+    }
+
+    return(0);
+}
+
+sub ShowSystemSections {
     my $skip_section = 0;
     while (<INPUT>) {
 	# delete rare characters
 	tr/\015//d;
 
 	# finish cases
-	return(-1) if (/command authorization failed/i);
 	last if(/^$prompt/);
 
 	# new section comes, reset skip
@@ -193,7 +209,25 @@ sub ShowSystem {
 	next if ($skip_section);
 	ProcessHistory("COMMENTS","keysort","B0", "!$_") && next;
     }
-    return(0);
+}
+
+sub ShowSystemLines {
+    while (<INPUT>) {
+	# delete rare characters
+	tr/\015//d;
+
+	# finish cases
+	last if(/^$prompt/);
+
+	# remove lines
+	next if(/^(\s*|\s*$cmd\s*)$/);
+	next if(/Up Time/);
+	# finish lines
+	last if(/Unit\s*Temperature/);
+
+	# if not skiped, save the log
+	ProcessHistory("COMMENTS","keysort","B0", "!$_") && next;
+    }
 }
 
 # This routine parses "show version"


### PR DESCRIPTION
This patch is to fix #14 and support multiple "show system" commands.

According to #14 there are at least two outputs of "show system" command that must be parsed correctly.