### PR TITLE
Tweak regex to deal with config mode prompts

### DIFF
--- a/src/csblogin
+++ b/src/csblogin
@@ -467,7 +467,7 @@ proc run_commands { prompt command } {
 	    expect {
 		-re "^\[^\n\r *]*$prompt *$"	{}
 		-re "^\[^\n\r]*$prompt."	{ exp_continue }
-		-re "(\r\n|\n)"			{ exp_continue }
+		-re "\[\r\n]+"			{ exp_continue }
             }
 	}
     } else {
@@ -475,7 +475,7 @@ proc run_commands { prompt command } {
 	expect {
 		-re "^\[^\n\r *]*$prompt *$"	{}
 		-re "^\[^\n\r]*$prompt."	{ exp_continue }
-		-re "(\r\n|\n)"			{ exp_continue }
+		-re "\[\r\n]+"			{ exp_continue }
 	}
     }
     send "exit\r\n"


### PR DESCRIPTION
With this change, I can do config mode commands with `csblogin`, (apparently) fixing the issue described in #17 

I tried a `csbrancid` using this modified `csblogin` and the generated output looks accurate.